### PR TITLE
Transition Opacity for Site Head & Nav

### DIFF
--- a/src/assets/css/_sass/components/_site-header.scss
+++ b/src/assets/css/_sass/components/_site-header.scss
@@ -5,6 +5,11 @@
   border-bottom: 4px solid $color-yellow;
   z-index: $z-site-header;
   @include padding-vertical($gutter--large, $gutter);
+  @include transition;
+
+  &.opaque {
+    background-color: $color-grey--lightest
+  }
 }
 
 .site-header__wrapper {
@@ -19,7 +24,8 @@
 .site-logo {
   font-size: 0;
   @include margin-center;
-  @include icon--color(white)
+  @include icon--color($color-grey--lightest)
+  @include transition;
 
   @include screen($bp-desktop) {
     flex-basis: calc(100% / 3 * 2);
@@ -41,6 +47,10 @@
     @include screen($bp-desktop) {
       @include margin-horizontal(0); // reset position
     }
+  }
+
+  @at-root .opaque #{&} {
+    @include icon--color($color-grey--darkest);
   }
 
   span {

--- a/src/assets/css/_sass/components/_site-nav.scss
+++ b/src/assets/css/_sass/components/_site-nav.scss
@@ -33,6 +33,12 @@
         box-shadow: inset 0 0 0 1px currentColor; // create sizeless border
         @include transition;
         @include padding-horizontal(48px);
+
+        @at-root .opaque #{&} {
+          color: $color-grey--darkest;
+          background-color: $color-yellow;
+          box-shadow: inset 0 0 0 1px $color-yellow; // create sizeless border
+        }
       }
     }
   }
@@ -46,12 +52,17 @@
   font-size: 14px;
   text-decoration: none;
   color: $color-blue--dark;
+  @include transition;
 
   @include screen($bp-desktop) {
     font-size: 16px;
     color: $color-text--light;
     font-weight: bold;
     text-transform: uppercase;
+  }
+
+  @at-root .opaque #{&} {
+    color: $color-grey--darkest;
   }
 }
 

--- a/src/assets/js/opaque-nav.js
+++ b/src/assets/js/opaque-nav.js
@@ -1,0 +1,11 @@
+function toggleFade(position) {
+  const el = $('.site-header');
+  position > 200 ? el.addClass('opaque') : el.removeClass('opaque');
+}
+
+function scrollHandler() {
+  toggleFade($(this).scrollTop());
+}
+
+$(document).ready(scrollHandler);
+$(document).scroll(scrollHandler);


### PR DESCRIPTION
Adds in a scrollspy which will toggle navigation opacity using the class `.opaque`
Individual components can watch for this class and adjust desired styles based on state.