### PR TITLE
Add collapse support for multiple Content Sections

### DIFF
--- a/src/_includes/components/collapsible-list.html
+++ b/src/_includes/components/collapsible-list.html
@@ -6,10 +6,13 @@
 {% for section in content %}
   {% if forloop.index > 1 %}
     {% assign content_block = section | split: "</h4>" %}
-    <div class="service-list__collapsible-item collapsible-item">
-      <input class="collapsible-item__handle" type="checkbox" id="service-list-{{ forloop.index }}">
 
-      <label class="collapsible-item__label" for="service-list-{{ forloop.index }}">
+    {% assign content_id = content_block[0] | strip_html | replace: ' ', '_' %}
+
+    <div class="service-list__collapsible-item collapsible-item">
+      <input class="collapsible-item__handle" type="checkbox" id="service-list-{{ content_id }}">
+
+      <label class="collapsible-item__label" for="service-list-{{ content_id }}">
         <img class="collapsible-item__carat" src="/assets/icons/carat_facing_down.svg" alt=""/>
         {{ content_block[0] }}</h4>
       </label>


### PR DESCRIPTION
The existing implementation would loop over each section creating a
service-list-id for each content item using a loop and the current
iterations index. When using multiple sections, the subsequent
sections would redefine the service-list-id from it's loop index, and not
the with the index of the whole count of content.

The easy solution is to use the content title as a id slug instead of
the loop item index.